### PR TITLE
Added way to send requests to forward proxy for enabled customer and data sources

### DIFF
--- a/src/main/java/com/glean/proxy/ChainedProxyConfiguration.java
+++ b/src/main/java/com/glean/proxy/ChainedProxyConfiguration.java
@@ -29,7 +29,12 @@ public class ChainedProxyConfiguration {
         Queue<ChainedProxy> chainedProxies,
         ClientDetails clientDetails) -> {
             String hostHeader = httpRequest.headers().get("Host");
-            String host = hostHeader != null ? hostHeader.split(":")[0] : "";
+            if (hostHeader == null) {
+                chainedProxies.add(ChainedProxyAdapter.FALLBACK_TO_DIRECT_CONNECTION);
+                logger.severe("No host header found, falling back to direct connection");
+                return;
+            }
+            String host = hostHeader.split(":")[0];
             
             if (dataSourceHosts.contains(host)) {
                 chainedProxies.add(new ChainedProxyAdapter() {

--- a/src/main/java/com/glean/proxy/ChainedProxyConfiguration.java
+++ b/src/main/java/com/glean/proxy/ChainedProxyConfiguration.java
@@ -1,0 +1,57 @@
+package com.glean.proxy;
+
+import java.net.InetSocketAddress;
+import java.util.Queue;
+import java.util.Set;
+import org.littleshoot.proxy.ChainedProxy;
+import org.littleshoot.proxy.ChainedProxyAdapter;
+import org.littleshoot.proxy.impl.ClientDetails;
+import java.util.logging.Logger;
+import org.littleshoot.proxy.ChainedProxyManager;
+import io.netty.handler.codec.http.HttpRequest;
+
+
+public class ChainedProxyConfiguration {
+    private static final Logger logger = Logger.getLogger(ChainedProxyConfiguration.class.getName());
+    
+    public static ChainedProxyManager fromEnvironment() {
+        if (System.getenv("FORWARD_PROXY_HOST") == null || System.getenv("FORWARD_PROXY_PORT") == null || System.getenv("FORWARD_PROXY_DATA_SOURCE_HOSTS") == null) {
+            return (HttpRequest httpRequest,
+            Queue<ChainedProxy> chainedProxies,
+            ClientDetails clientDetails) -> {
+                chainedProxies.add(ChainedProxyAdapter.FALLBACK_TO_DIRECT_CONNECTION);
+            };
+        }
+        InetSocketAddress forwardProxy = new InetSocketAddress(System.getenv("FORWARD_PROXY_HOST"), Integer.parseInt(System.getenv("FORWARD_PROXY_PORT"))); 
+        Set<String> dataSourceHosts = Set.of(System.getenv("FORWARD_PROXY_DATA_SOURCE_HOSTS").split(","));
+        
+        ChainedProxyManager chainedProxyManager = (HttpRequest httpRequest,
+        Queue<ChainedProxy> chainedProxies,
+        ClientDetails clientDetails) -> {
+            String hostHeader = httpRequest.headers().get("Host");
+            String host = hostHeader != null ? hostHeader.split(":")[0] : "";
+            
+            if (dataSourceHosts.contains(host)) {
+                chainedProxies.add(new ChainedProxyAdapter() {
+                    @Override
+                    public InetSocketAddress getChainedProxyAddress() {
+                        return forwardProxy;
+                    }
+                      
+                    @Override
+                    public String getUsername() {
+                        return System.getenv("FORWARD_PROXY_USERNAME");
+                    }
+                    
+                    @Override
+                    public String getPassword() {
+                        return System.getenv("FORWARD_PROXY_PASSWORD");
+                    }
+                });
+            } else {
+                chainedProxies.add(ChainedProxyAdapter.FALLBACK_TO_DIRECT_CONNECTION);
+            }
+        };
+        return chainedProxyManager;
+    }
+}

--- a/src/main/java/com/glean/proxy/ProxyNetworking.java
+++ b/src/main/java/com/glean/proxy/ProxyNetworking.java
@@ -2,6 +2,7 @@ package com.glean.proxy;
 
 import java.net.InetSocketAddress;
 import java.util.logging.Logger;
+import org.littleshoot.proxy.ChainedProxyManager;
 import org.littleshoot.proxy.HttpProxyServer;
 import org.littleshoot.proxy.impl.DefaultHttpProxyServer;
 import org.littleshoot.proxy.impl.ThreadPoolConfiguration;
@@ -11,6 +12,7 @@ public class ProxyNetworking {
 
   protected final ThreadPoolConfiguration threadPoolConfiguration;
   protected final FilterConfiguration filterConfiguration;
+  protected final ChainedProxyManager chainedProxyManager;
 
   public void run(int port) {
     DynamicHttpFiltersSourceAdapter filtersSource =
@@ -23,6 +25,7 @@ public class ProxyNetworking {
             .withIdleConnectionTimeout(1200) // seconds
             .withThreadPoolConfiguration(threadPoolConfiguration)
             .withFiltersSource(filtersSource)
+            .withChainProxyManager(chainedProxyManager)
             .start();
     try {
       Thread.sleep(Long.MAX_VALUE);
@@ -35,6 +38,7 @@ public class ProxyNetworking {
   private ProxyNetworking(Builder builder) {
     threadPoolConfiguration = builder.threadPoolConfiguration;
     filterConfiguration = builder.filterConfiguration;
+    chainedProxyManager = builder.chainedProxyManager;
   }
 
   public static Builder builder() {
@@ -44,7 +48,8 @@ public class ProxyNetworking {
   public static class Builder {
     private ThreadPoolConfiguration threadPoolConfiguration;
     private FilterConfiguration filterConfiguration;
-
+    private ChainedProxyManager chainedProxyManager;
+    
     public Builder withThreadPoolConfiguration(ThreadPoolConfiguration threadPoolConfiguration) {
       this.threadPoolConfiguration = threadPoolConfiguration;
       return this;
@@ -55,12 +60,20 @@ public class ProxyNetworking {
       return this;
     }
 
+    public Builder withChainedProxyManager(ChainedProxyManager chainedProxyManager) {
+      this.chainedProxyManager = chainedProxyManager;
+      return this;
+    }
+
     public ProxyNetworking build() {
       if (threadPoolConfiguration == null) {
         threadPoolConfiguration = createThreadPoolConfigurationFromEnvironment();
       }
       if (filterConfiguration == null) {
         filterConfiguration = FilterConfiguration.fromEnvironment();
+      }
+      if (chainedProxyManager == null) {
+        chainedProxyManager = ChainedProxyConfiguration.fromEnvironment();
       }
       return new ProxyNetworking(this);
     }


### PR DESCRIPTION
**Description**:
Currently our glean-proxy will make a direct connection to a data source. We want to provide a way to route these requests via forward proxy. So that the requests can be monitored by the forward proxy.

We need to set the following environment variables to make the requests go through the forward proxy:
```
export FORWARD_PROXY_HOST=<forward-proxy-host>
export FORWARD_PROXY_PORT=<forward-proxy-port>
export FORWARD_PROXY_DATA_SOURCE_HOSTS=<Comma seperated list of data source hosts>
export FORWARD_PROXY_USERNAME=<Username of the forward proxy>
export FORWARD_PROXY_PASSWORD=<Password of the forward proxy>
```

**Context**:

We needed this so that the customer can host a forward proxy which can inspect all the requests going to the data sources.


**Test plan**:
Ran the glean-proxy server with the following environment variable 
`bazel run //src/main/java/com/glean/proxy:ProxyMain 8080`
Environment variables
```
export CLOUD_PLATFORM=AWS
export AWS_FILTERS=
export GOOGLE_FILTERS=
export CROSS_PLATFORM_FILTERS=
export DEBUG_FILTERS=
export FORWARD_PROXY_HOST=localhost
export FORWARD_PROXY_PORT=8888
export FORWARD_PROXY_DATA_SOURCE_HOSTS=www.google.com,www.glean.com
export FORWARD_PROXY_USERNAME=
export FORWARD_PROXY_PASSWORD=
```

For the forward proxy we just used the glean-proxy to run as forward proxy with a different port
`bazel run //src/main/java/com/glean/proxy:ProxyMain 8888`
Environment variables
```
export CLOUD_PLATFORM=AWS
export AWS_FILTERS=
export GOOGLE_FILTERS=
export CROSS_PLATFORM_FILTERS=
export DEBUG_FILTERS=
```

Made the following requests
1. `curl --proxy localhost:8080 https://www.example.com`
2. `curl --proxy localhost:8080 https://www.google.com`

Screenshot of glean-proxy at 8080 logs 
<img width="1295" height="542" alt="Screenshot 2025-10-27 at 11 34 47 AM" src="https://github.com/user-attachments/assets/6bdb0bbc-f5ea-4e08-a559-645cfbf85b3b" />

Screenshot of forward-proxy at 8888 logs
<img width="1234" height="486" alt="Screenshot 2025-10-27 at 11 34 30 AM" src="https://github.com/user-attachments/assets/46543d12-603d-41e1-92a1-566240830001" />

As you see only `www.google.com` went through the forward proxy and `www.example.com` doesn't have any log in the forward proxy as it is a direct connection

---

**Change Type**
  - [ ] Flag-gated development/Internal fix
  - [ ] Bug Fix/Enhancement
  - [ ] Security or Permissions related change
  - [x] Feature launch

**Platform (Choose one if applicable)**
  - [ ] AWS only change
  - [ ] GCP only change
