### PR TITLE
Handled empty string passed for FORWARD_PROXY variables

### DIFF
--- a/src/main/java/com/glean/proxy/ChainedProxyConfiguration.java
+++ b/src/main/java/com/glean/proxy/ChainedProxyConfiguration.java
@@ -15,15 +15,20 @@ public class ChainedProxyConfiguration {
     private static final Logger logger = Logger.getLogger(ChainedProxyConfiguration.class.getName());
     
     public static ChainedProxyManager fromEnvironment() {
-        if (System.getenv("FORWARD_PROXY_HOST") == null || System.getenv("FORWARD_PROXY_PORT") == null || System.getenv("FORWARD_PROXY_DATA_SOURCE_HOSTS") == null) {
+        String forwardProxyHost = System.getenv("FORWARD_PROXY_HOST");
+        String forwardProxyPort = System.getenv("FORWARD_PROXY_PORT");
+        String dataSourceHostsEnv = System.getenv("FORWARD_PROXY_DATA_SOURCE_HOSTS");
+        if (forwardProxyHost == null || forwardProxyHost.isEmpty() ||
+            forwardProxyPort == null || forwardProxyPort.isEmpty() ||
+            dataSourceHostsEnv == null || dataSourceHostsEnv.isEmpty()) {
             return (HttpRequest httpRequest,
             Queue<ChainedProxy> chainedProxies,
             ClientDetails clientDetails) -> {
                 chainedProxies.add(ChainedProxyAdapter.FALLBACK_TO_DIRECT_CONNECTION);
             };
         }
-        InetSocketAddress forwardProxy = new InetSocketAddress(System.getenv("FORWARD_PROXY_HOST"), Integer.parseInt(System.getenv("FORWARD_PROXY_PORT"))); 
-        Set<String> dataSourceHosts = Set.of(System.getenv("FORWARD_PROXY_DATA_SOURCE_HOSTS").split(","));
+        InetSocketAddress forwardProxy = new InetSocketAddress(forwardProxyHost, Integer.parseInt(forwardProxyPort)); 
+        Set<String> dataSourceHosts = Set.of(dataSourceHostsEnv.split(","));
         
         ChainedProxyManager chainedProxyManager = (HttpRequest httpRequest,
         Queue<ChainedProxy> chainedProxies,


### PR DESCRIPTION
**Description**:

**Context**:

**Test plan**:
Ran the glean-proxy server with the following environment variable 
`bazel run //src/main/java/com/glean/proxy:ProxyMain 8080`
Environment variables
```
export CLOUD_PLATFORM=AWS
export AWS_FILTERS=
export GOOGLE_FILTERS=
export CROSS_PLATFORM_FILTERS=
export DEBUG_FILTERS=
export FORWARD_PROXY_HOST=localhost
export FORWARD_PROXY_PORT=8888
export FORWARD_PROXY_DATA_SOURCE_HOSTS=www.google.com,www.glean.com
export FORWARD_PROXY_USERNAME=
export FORWARD_PROXY_PASSWORD=
```

For the forward proxy we just used the glean-proxy to run as forward proxy with a different port
`bazel run //src/main/java/com/glean/proxy:ProxyMain 8888`
Environment variables
```
export CLOUD_PLATFORM=AWS
export AWS_FILTERS=
export GOOGLE_FILTERS=
export CROSS_PLATFORM_FILTERS=
export DEBUG_FILTERS=
```

Made the following requests
1. `curl --proxy localhost:8080 https://www.example.com`
2. `curl --proxy localhost:8080 https://www.google.com`

Screenshot of glean-proxy at 8080 logs 
<img width="1295" height="542" alt="Screenshot 2025-10-27 at 11 34 47 AM" src="https://github.com/user-attachments/assets/6bdb0bbc-f5ea-4e08-a559-645cfbf85b3b" />

Screenshot of forward-proxy at 8888 logs
<img width="1234" height="486" alt="Screenshot 2025-10-27 at 11 34 30 AM" src="https://github.com/user-attachments/assets/46543d12-603d-41e1-92a1-566240830001" />

As you see only `www.google.com` went through the forward proxy and `www.example.com` doesn't have any log in the forward proxy as it is a direct connection

---

**Change Type**
  - [ ] Flag-gated development/Internal fix
  - [ ] Bug Fix/Enhancement
  - [ ] Security or Permissions related change
  - [x] Feature launch

**Platform (Choose one if applicable)**
  - [ ] AWS only change
  - [ ] GCP only change
