### PR TITLE
[NI][Proxy] Set content length header in bad request response

### DIFF
--- a/src/main/java/com/glean/proxy/filters/LegacyRequestFilter.java
+++ b/src/main/java/com/glean/proxy/filters/LegacyRequestFilter.java
@@ -93,6 +93,7 @@ public class LegacyRequestFilter extends HttpFiltersAdapter {
             HttpResponseStatus.BAD_REQUEST,
             Unpooled.copiedBuffer(message, CharsetUtil.UTF_8));
     response.headers().set("Content-Type", "text/plain; charset=UTF-8");
+    response.headers().set("Content-Length", response.content().readableBytes());
     return response;
   }
 }


### PR DESCRIPTION
**Description**: Curl command to proxy with bad requests hangs because it is waiting for the server to close the connection because it doesn't know how much data to expect.
Setting content length header fixes this case. 

**Context**:

**Test plan**:

---

**Change Type**
  - [x] Flag-gated development/Internal fix
  - [ ] Bug Fix/Enhancement
  - [ ] Security or Permissions related change
  - [ ] Feature launch

**Platform (Choose one if applicable)**
  - [ ] AWS only change
  - [ ] GCP only change
