### PR TITLE
Route direct /api/ and /rest/ paths to DSE when ALLOW_API_INGRESS=true

### DIFF
--- a/src/main/java/com/glean/proxy/DynamicHttpFiltersSourceAdapter.java
+++ b/src/main/java/com/glean/proxy/DynamicHttpFiltersSourceAdapter.java
@@ -23,6 +23,8 @@ public class DynamicHttpFiltersSourceAdapter extends HttpFiltersSourceAdapter {
       Logger.getLogger(DynamicHttpFiltersSourceAdapter.class.getName());
   private final OnPremisesProxy legacyProxy = OnPremisesProxy.fromEnvironment();
   private final String cloudPlatform = System.getenv("CLOUD_PLATFORM");
+  private final boolean allowApiIngress =
+      "true".equalsIgnoreCase(System.getenv("ALLOW_API_INGRESS"));
 
   private final List<BiFunction<HttpRequest, ChannelHandlerContext, HttpFilters>> awsFilters;
   private final List<BiFunction<HttpRequest, ChannelHandlerContext, HttpFilters>> gcpFilters;
@@ -66,6 +68,15 @@ public class DynamicHttpFiltersSourceAdapter extends HttpFiltersSourceAdapter {
         logger.fine("Using HttpNotFoundFilter as legacy proxy is null");
         return new HttpNotFoundFilter(originalRequest);
       }
+    } else if (allowApiIngress && isDirectApiPath(originalRequest.uri())) {
+      if (legacyProxy != null) {
+        logger.info("Direct API path detected, routing to LegacyRequestFilter: "
+            + originalRequest.uri());
+        return new LegacyRequestFilter(originalRequest, legacyProxy, true);
+      } else {
+        logger.fine("Using HttpNotFoundFilter as legacy proxy is null");
+        return new HttpNotFoundFilter(originalRequest);
+      }
     }
 
     return switch (cloudPlatform) {
@@ -87,5 +98,9 @@ public class DynamicHttpFiltersSourceAdapter extends HttpFiltersSourceAdapter {
             .collect(Collectors.toCollection(ArrayList::new));
 
     return new CompositeFilter(originalRequest, filters);
+  }
+
+  private static boolean isDirectApiPath(String uri) {
+    return uri.startsWith("/api/") || uri.startsWith("/rest/");
   }
 }

--- a/src/main/java/com/glean/proxy/filters/LegacyRequestFilter.java
+++ b/src/main/java/com/glean/proxy/filters/LegacyRequestFilter.java
@@ -22,17 +22,29 @@ import org.littleshoot.proxy.HttpFiltersAdapter;
 public class LegacyRequestFilter extends HttpFiltersAdapter {
   private static final Logger LOGGER = Logger.getLogger(LegacyRequestFilter.class.getName());
   private final OnPremisesProxy legacyProxy;
+  private final boolean directApiPath;
   private static final String PROXY_HEADER = "OnPrem-Proxy";
 
   public LegacyRequestFilter(HttpRequest originalRequest, OnPremisesProxy legacyProxy) {
+    this(originalRequest, legacyProxy, false);
+  }
+
+  public LegacyRequestFilter(
+      HttpRequest originalRequest, OnPremisesProxy legacyProxy, boolean directApiPath) {
     super(originalRequest);
     this.legacyProxy = legacyProxy;
+    this.directApiPath = directApiPath;
   }
 
   @Override
   public HttpResponse clientToProxyRequest(HttpObject httpObject) {
     if (httpObject instanceof HttpRequest) {
       final HttpRequest httpRequest = (HttpRequest) httpObject;
+
+      if (directApiPath) {
+        httpRequest.setUri("/proxy" + httpRequest.uri());
+      }
+
       final String[] splitPath = httpRequest.uri().split("/", 4);
       if (splitPath.length < 3) {
         LOGGER.severe(String.format("Unexpected legacy request format: %s", httpRequest.uri()));


### PR DESCRIPTION
## Summary
- Customers connecting via TGW send requests to `/api/...` directly, without the `/proxy/` prefix that the proxy requires. This caused requests to fall through to the AWS egress filter chain, resulting in 400 errors or long timeouts (15-20 min as reported by Ericsson).
- When `ALLOW_API_INGRESS=true`, the proxy now recognizes direct `/api/` and `/rest/` paths and routes them through `LegacyRequestFilter` with the `/proxy/` prefix prepended internally.
- The existing `/proxy/api/` path continues to work unchanged.

## Test plan
Tested end-to-end from TGW test instance (192.168.3.211 in aws-salessavvy-test) → proxy VM (10.50.0.20:8080 in aws-sasandbox) → DSE LB (10.50.0.17):

| Path | Before Fix | After Fix |
|------|-----------|-----------|
| `/api/index/v1/indexdocument` | 400 Bad Request | **401** (reaches DSE, 56ms) |
| `/proxy/api/index/v1/indexdocument` | 401 (working) | **401** (unchanged, 55ms) |
| `/rest/api/v2/test` | 400 Bad Request | **404** (reaches DSE, 28ms) |
| `/liveness_check` | 200 OK | **200 OK** (7ms) |

Proxy logs confirm the rewrite:
```
Direct API path detected, routing to LegacyRequestFilter: /api/index/v1/indexdocument
```

All 9 existing unit tests pass.