### PR TITLE
[BugFix] Allow request body cap to be set via MAX_REQUEST_BUFFER_BYTES

### DIFF
--- a/src/main/java/com/glean/proxy/DynamicHttpFiltersSourceAdapter.java
+++ b/src/main/java/com/glean/proxy/DynamicHttpFiltersSourceAdapter.java
@@ -39,9 +39,9 @@ public class DynamicHttpFiltersSourceAdapter extends HttpFiltersSourceAdapter {
 
   // Aggregate the request body so filters can operate on a FullHttpRequest. Requests larger than
   // this cap are rejected with HTTP 413 by Netty's HttpObjectAggregator before any filter runs.
-  // Override the cap via MAX_REQUEST_BUFFER_BYTES — required for endpoints like
-  // /api/index/v1/indexdocuments where customers send payloads well over the default.
-  private static final int DEFAULT_MAX_REQUEST_BUFFER_BYTES = 64 * 1024 * 1024; // 64 MB
+  // Override the default 5 MB cap via MAX_REQUEST_BUFFER_BYTES — required for endpoints like
+  // /api/index/v1/indexdocuments where customers send payloads well over 5 MB.
+  private static final int DEFAULT_MAX_REQUEST_BUFFER_BYTES = 5 * 1024 * 1024; // 5 MB
 
   private static final int MAX_REQUEST_BUFFER_BYTES = resolveMaxRequestBufferBytes();
 

--- a/src/main/java/com/glean/proxy/DynamicHttpFiltersSourceAdapter.java
+++ b/src/main/java/com/glean/proxy/DynamicHttpFiltersSourceAdapter.java
@@ -37,14 +37,43 @@ public class DynamicHttpFiltersSourceAdapter extends HttpFiltersSourceAdapter {
     debugFilters = new ArrayList<>(config.debugFilters());
   }
 
-  // Adding a 5 MB buffer to ensure the HttpRequest is aggregated. Without this, the request may be
-  // received in chunks. This is necessary because we handle proxy-to-server connections ourselves
-  // for requests coming from the customer. By enabling aggregation, we avoid having to manually
-  // handle chunked requests. Note that the requests with size greater than 5 MB will automatically
-  // be rejected at an upper layer.
+  // Aggregate the request body so filters can operate on a FullHttpRequest. Requests larger than
+  // this cap are rejected with HTTP 413 by Netty's HttpObjectAggregator before any filter runs.
+  // Override the cap via MAX_REQUEST_BUFFER_BYTES — required for endpoints like
+  // /api/index/v1/indexdocuments where customers send payloads well over the default.
+  private static final int DEFAULT_MAX_REQUEST_BUFFER_BYTES = 64 * 1024 * 1024; // 64 MB
+
+  private static final int MAX_REQUEST_BUFFER_BYTES = resolveMaxRequestBufferBytes();
+
+  private static int resolveMaxRequestBufferBytes() {
+    String raw = System.getenv("MAX_REQUEST_BUFFER_BYTES");
+    if (raw == null || raw.isBlank()) {
+      return DEFAULT_MAX_REQUEST_BUFFER_BYTES;
+    }
+    try {
+      int parsed = Integer.parseInt(raw.trim());
+      if (parsed <= 0) {
+        logger.warning(
+            "MAX_REQUEST_BUFFER_BYTES must be positive; got "
+                + parsed
+                + ". Falling back to default "
+                + DEFAULT_MAX_REQUEST_BUFFER_BYTES);
+        return DEFAULT_MAX_REQUEST_BUFFER_BYTES;
+      }
+      return parsed;
+    } catch (NumberFormatException e) {
+      logger.warning(
+          "MAX_REQUEST_BUFFER_BYTES is not a valid integer: '"
+              + raw
+              + "'. Falling back to default "
+              + DEFAULT_MAX_REQUEST_BUFFER_BYTES);
+      return DEFAULT_MAX_REQUEST_BUFFER_BYTES;
+    }
+  }
+
   @Override
   public int getMaximumRequestBufferSizeInBytes() {
-    return 5 * 1024 * 1024; // 5 mb
+    return MAX_REQUEST_BUFFER_BYTES;
   }
 
   @Override


### PR DESCRIPTION
**Description**: `DynamicHttpFiltersSourceAdapter.getMaximumRequestBufferSizeInBytes()` is hard-coded to 5 MB, which becomes the `maxContentLength` LittleProxy passes to Netty's `HttpObjectAggregator`. Any request body above 5 MB is rejected with HTTP 413 inside the aggregator before any filter runs.

This change reads the cap from a new `MAX_REQUEST_BUFFER_BYTES` env var (positive integer, bytes). When unset/invalid/non-positive, it falls back to the existing 5 MB default — so existing deployments are unaffected. Customers who need a larger cap (e.g. for `/api/index/v1/indexdocuments`) set the env var explicitly.

**Context**: Ericsson on-prem proxy traffic to `/api/index/v1/indexdocuments` was returning 413 for ~28 MB document payloads, while the same request worked when bypassing the proxy and hitting DSE directly. Root cause was the hard-coded 5 MB cap; DSE itself does not enforce an HTTP body-size limit at the framework level.

**Test plan**: End-to-end repro and fix verified in `sa-sandbox` proxy VM (10.50.0.20) from `aws-salessavvy-test` test VM via TGW.

With the patched JAR deployed and `MAX_REQUEST_BUFFER_BYTES=67108864` (64 MB):

| Body size | Before (5 MB hard-coded) | After (env-set to 64 MB) |
|---|---|---|
| 4.5 MB | 400 (under cap) | 400 (under cap) |
| 5.15 MB | **413, upload=0** | 400, upload=5403512 — body fully read |
| 28.3 MB (Ericsson size) | **413, upload=0** | 400, upload=29719301 — body fully read |
| 64.4 MB | n/a | **413, upload=0** — new cap enforced |

(The 400 in the post-fix column is the proxy's own URI-routing rejection downstream of aggregation, because the repro path bypasses the inbound NLB and doesn't carry full auth context — irrelevant to the size-cap bug; what matters is that `upload` now matches the file size.)

Also confirmed the patched class is what's actually running by extracting `DynamicHttpFiltersSourceAdapter.class` from the JAR inside the container and verifying the new symbols (`MAX_REQUEST_BUFFER_BYTES`, `resolveMaxRequestBufferBytes`, `DEFAULT_MAX_REQUEST_BUFFER_BYTES`) are present in the bytecode.

With the env var unset, the cap stays at 5 MB exactly as before.

---

**Change Type**
  - [ ] Flag-gated development/Internal fix
  - [x] Bug Fix/Enhancement
  - [ ] Security or Permissions related change
  - [ ] Feature launch

**Platform (Choose one if applicable)**
  - [ ] AWS only change
  - [ ] GCP only change